### PR TITLE
Update question 4 on use cases of matplotlib doc in 2024_questions.md

### DIFF
--- a/2024_questions.md
+++ b/2024_questions.md
@@ -28,15 +28,15 @@ Linear scale
 - 1 - Not helpful at all (never use documentation)
 - 5 - Very helpful (frequently and regularly use documentation)
 
-## Select the best descriptions for how you value and use the Matplotlib documentation.
+## How do you use the Matplotlib documentation? Select all options that apply.
 
 Checkboxes
 
 - I use the docs to help me develop software.
-- I read the docs to help me learn about Python, data science, and visualization.
-- I read the docs to study for course work for an academic discipline (e.g. mathematics, economics, biology, history, etc.)
-- I use the docs to support my work in research projects (for example, industry, science, digital humanities, etc.)
-- I contribute to the docs and work with the community with other scientific Python projects.
+- I read the docs to learn about Python programming, data science, and data visualization.
+- I refer to the docs to support my academic coursework.
+- I use the docs for research projects in various fields.
+- I contribute to the docs.
 - Other 
 
 ## How do you read Matplotlib API documentation or docstrings? Rank the following options from most likely to least likely.


### PR DESCRIPTION
It wasn't clear from previous wording of the question if respondents should only select the top use case ("best descriptions") or all common use cases.

Also suggest to remove "collaborate with the community on other scientific Python projects"; it overlaps with the earlier option of "research projects" and people may contribute to the docs without being part of a scientific project.